### PR TITLE
Treat `Symbol` as a `string` type, not `object`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,12 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+      exclude:
+        - github-runner: macos-latest # Apple Silicon
+          julia-version: 'min'
+      include:
+        - github-runner: macos-13 # Intel
+          julia-version: 'min'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags: "*"
+
+concurrency:
+  # Skip intermediate builds: all builds except for builds on the `main` branch
+  # Cancel intermediate builds: only pull request builds
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/main' || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "min"
+          - "1"
+          - "nightly"
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,11 +29,11 @@ jobs:
           - macOS-latest
           - windows-latest
         exclude:
-          - github-runner: macos-latest # Apple Silicon
-            julia-version: 'min'
+          - os: macos-latest # Apple Silicon
+            version: 'min'
         include:
-          - github-runner: macos-13 # Intel
-            julia-version: 'min'
+          - os: macos-13 # Intel
+            version: 'min'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,12 +28,12 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-      exclude:
-        - github-runner: macos-latest # Apple Silicon
-          julia-version: 'min'
-      include:
-        - github-runner: macos-13 # Intel
-          julia-version: 'min'
+        exclude:
+          - github-runner: macos-latest # Apple Silicon
+            julia-version: 'min'
+        include:
+          - github-runner: macos-13 # Intel
+            julia-version: 'min'
 
     steps:
       - uses: actions/checkout@v4

--- a/Project.toml
+++ b/Project.toml
@@ -9,11 +9,11 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
-julia = "1"
-Dates = "1"
+Dates = "<0.0.1, 1"
+JSONSchema = "< 1.4.2"
 OrderedCollections = "1.4"
 StructTypes = "1.8"
-JSONSchema = "< 1.4.1"
+julia = "1"
 
 [extras]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ authors = ["matthijscox <matthijs.cox@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
 julia = "1"
+Dates = "1"
 OrderedCollections = "1.4"
 StructTypes = "1.8"
 

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ julia = "1"
 Dates = "1"
 OrderedCollections = "1.4"
 StructTypes = "1.8"
+JSONSchema = "< 1.4.1"
 
 [extras]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
 Dates = "<0.0.1, 1"
-JSONSchema = "< 1.4.2"
+JSONSchema = "< 1.4.1"
 OrderedCollections = "1.4"
 StructTypes = "1.8"
 julia = "1"

--- a/src/JSONSchemaGenerator.jl
+++ b/src/JSONSchemaGenerator.jl
@@ -4,6 +4,10 @@ import Dates
 import OrderedCollections: OrderedDict
 import StructTypes
 
+if !isdefined(Base, :fieldtypes) && VERSION < v"1.1"
+    fieldtypes(T::Type) = (Any[fieldtype(T, i) for i in 1:fieldcount(T)]...,)
+end
+
 # by default we assume the type is a custom type, which should be a JSON object
 _json_type(::Type{<:Any}) = :object
 #_json_type(::Type{<:AbstractDict}) = :object

--- a/src/JSONSchemaGenerator.jl
+++ b/src/JSONSchemaGenerator.jl
@@ -15,6 +15,7 @@ _json_type(::Type{Nothing}) = :null
 _json_type(::Type{Missing}) = :null
 _json_type(::Type{<:Enum}) = :enum
 _json_type(::Type{<:AbstractString}) = :string
+_json_type(::Type{Symbol}) = :string
 
 _is_nothing_union(::Type) = false
 _is_nothing_union(::Type{Nothing}) = false

--- a/src/JSONSchemaGenerator.jl
+++ b/src/JSONSchemaGenerator.jl
@@ -1,5 +1,6 @@
 module JSONSchemaGenerator
 
+import Dates
 import OrderedCollections: OrderedDict
 import StructTypes
 
@@ -16,6 +17,11 @@ _json_type(::Type{Missing}) = :null
 _json_type(::Type{<:Enum}) = :enum
 _json_type(::Type{<:AbstractString}) = :string
 _json_type(::Type{Symbol}) = :string
+_json_type(::Type{<:AbstractChar}) = :string
+_json_type(::Type{Base.UUID}) = :string
+_json_type(::Type{T}) where {T <: Dates.TimeType} = :string
+_json_type(::Type{VersionNumber}) = :string
+_json_type(::Type{Base.Regex}) = :string
 
 _is_nothing_union(::Type) = false
 _is_nothing_union(::Type{Nothing}) = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ module TestTypes
         int::Int64
         float::Float64
         string::String
+        symbol::Symbol
     end
     StructTypes.StructType(::Type{BasicSchema}) = StructTypes.Struct()
 
@@ -92,15 +93,16 @@ end
 @testset "Basic Types" begin
     json_schema = JSONSchemaGenerator.schema(TestTypes.BasicSchema)
     @test json_schema["type"] == "object"
-    object_properties = ["int", "float", "string"]
+    object_properties = ["int", "float", "string", "symbol"]
     @test all(x in object_properties for x in json_schema["required"])
     @test all(x in object_properties for x in keys(json_schema["properties"]))
 
     @test json_schema["properties"]["int"]["type"] == "integer"
     @test json_schema["properties"]["float"]["type"] == "number"
     @test json_schema["properties"]["string"]["type"] == "string"
+    @test json_schema["properties"]["symbol"]["type"] == "string"
 
-    test_json_schema_validation(TestTypes.BasicSchema(1, 1.0, "a"))
+    test_json_schema_validation(TestTypes.BasicSchema(1, 1.0, "a", :b))
 end
 
 @testset "Enumerators" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,13 @@
 using JSONSchemaGenerator
 using Test
+using Dates
 using JSON
 using JSON3
 using JSONSchema
 using StructTypes
 
 module TestTypes
+    using Dates
     using StructTypes
 
     struct BasicSchema
@@ -13,6 +15,11 @@ module TestTypes
         float::Float64
         string::String
         symbol::Symbol
+        char::Char
+        uuid::Base.UUID
+        timetype::Dates.DateTime
+        version_number::VersionNumber
+        regex::Regex
     end
     StructTypes.StructType(::Type{BasicSchema}) = StructTypes.Struct()
 
@@ -93,7 +100,7 @@ end
 @testset "Basic Types" begin
     json_schema = JSONSchemaGenerator.schema(TestTypes.BasicSchema)
     @test json_schema["type"] == "object"
-    object_properties = ["int", "float", "string", "symbol"]
+    object_properties = ["int", "float", "string", "symbol", "char", "uuid", "timetype", "version_number", "regex"]
     @test all(x in object_properties for x in json_schema["required"])
     @test all(x in object_properties for x in keys(json_schema["properties"]))
 
@@ -101,8 +108,13 @@ end
     @test json_schema["properties"]["float"]["type"] == "number"
     @test json_schema["properties"]["string"]["type"] == "string"
     @test json_schema["properties"]["symbol"]["type"] == "string"
+    @test json_schema["properties"]["char"]["type"] == "string"
+    @test json_schema["properties"]["uuid"]["type"] == "string"
+    @test json_schema["properties"]["timetype"]["type"] == "string"
+    @test json_schema["properties"]["version_number"]["type"] == "string"
+    @test json_schema["properties"]["regex"]["type"] == "string"
 
-    test_json_schema_validation(TestTypes.BasicSchema(1, 1.0, "a", :b))
+    test_json_schema_validation(TestTypes.BasicSchema(1, 1.0, "a", :b, 'c', Base.UUID(0), Dates.now(), v"0.0.1", r""))
 end
 
 @testset "Enumerators" begin


### PR DESCRIPTION
Thanks for the package @matthijscox.

Currently `Symbol` fields are treated as `object` rather than `string`, which, given that `StructTypes.jl` treats them as string-like suggests to me that that is the right behaviour here too: https://github.com/JuliaData/StructTypes.jl/blob/f3dd04929ec5afa15ccd782802af6ed0040d48d2/src/StructTypes.jl#L422

There's the rest of those `StringType`s in that link that might also be worth treating as `string` as well, aside from `<:Enum`. I can add those as well here if you'd like?