### PR TITLE
Added support for boolean combination keywords

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JSONSchemaGenerator"
 uuid = "b10a6b5e-eaef-4b72-b159-8e5005e98e8e"
 authors = ["matthijscox <matthijs.cox@gmail.com> and contributors"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -151,3 +151,45 @@ json_dict = JSON3.write(obj) |> JSON.parse
 
 JSONSchema.validate(JSONSchema.Schema(schema_dict), json_dict) === nothing
 ```
+
+## Boolean Combination Keywords
+
+JSONSchemaGenerator.jl provides special types `AllOf{T,S}`, `AnyOf{T,S}`, `OneOf{T,S}` and `Not{T}`, allowing generation of the corresponding JSON keyword (see [Boolean JSON Schema combination](https://json-schema.org/understanding-json-schema/reference/combining)). Note that more than two schemas can be combined by chaining: e.g. `AllOf{A, AllOf{B, C}}`.
+
+In the following example we combine some schemas that check if fields are equal to certain const values (using `Val` types):
+```julia
+import JSONSchemaGenerator as JSG
+using JSONSchema, JSON3
+
+struct ConstantInt1Schema
+    int::Val{1}
+end
+
+struct ConstantInt2Schema
+    int::Val{2}
+end
+
+struct ConstantBoolTrueSchema
+    bool::Val{true}
+end
+
+struct BooleanCombinationSchema
+    int::Int
+    bool::Bool
+    allOf::JSG.AllOf{
+        JSG.AnyOf{ConstantInt1Schema, ConstantInt2Schema},
+        JSG.Not{ConstantBoolTrueSchema}
+    }
+end
+function BooleanCombinationSchema(int::Int, bool::Bool)
+    return BooleanCombinationSchema(int, bool, JSG.AllOf{JSG.AnyOf{ConstantInt1Schema, ConstantInt2Schema}, JSG.Not{ConstantBoolTrueSchema}}())
+end
+
+schema = JSONSchema.Schema(JSG.schema(BooleanCombinationSchema))
+
+good_json = JSON3.write(BooleanCombinationSchema(2, false))
+bad_json = JSON3.write(BooleanCombinationSchema(5, true))
+
+JSONSchema.validate(schema, good_json) === nothing
+JSONSchema.validate(schema, bad_json) !== nothing
+```

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ JSONSchema.validate(JSONSchema.Schema(schema_dict), json_dict) === nothing
 
 JSONSchemaGenerator.jl provides special types `AllOf{T,S}`, `AnyOf{T,S}`, `OneOf{T,S}` and `Not{T}`, allowing generation of the corresponding JSON keyword (see [Boolean JSON Schema combination](https://json-schema.org/understanding-json-schema/reference/combining)). Note that more than two schemas can be combined by chaining: e.g. `AllOf{A, AllOf{B, C}}`.
 
+Fields of these types should be included in `StructTypes.excludes`.
+
 In the following example we combine some schemas that check if fields are equal to certain const values (using `Val` types):
 ```julia
 import JSONSchemaGenerator as JSG

--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ struct BooleanCombinationSchema
         JSG.Not{ConstantBoolTrueSchema}
     }
 end
+StructTypes.StructType(::Type{BooleanCombinationSchema}) = StructTypes.Struct()
+StructTypes.excludes(::Type{BooleanCombinationSchema}) = (:allOf,) # we don't actually want to see this element if (de)serializing with JSON3
+
 function BooleanCombinationSchema(int::Int, bool::Bool)
     return BooleanCombinationSchema(int, bool, JSG.AllOf{JSG.AnyOf{ConstantInt1Schema, ConstantInt2Schema}, JSG.Not{ConstantBoolTrueSchema}}())
 end

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ JSONSchemaGenerator.jl provides special types `AllOf{T,S}`, `AnyOf{T,S}`, `OneOf
 
 Fields of these types should be included in `StructTypes.excludes`.
 
-In the following example we combine some schemas that check if fields are equal to certain const values (using `Val` types):
+In the following example we combine some schemas that check if fields are equal to certain const values (using `Val` types, noting that these do not serialize well and should only be used for validation purposes like this):
 ```julia
 import JSONSchemaGenerator as JSG
 using JSONSchema, JSON3

--- a/README.md
+++ b/README.md
@@ -190,11 +190,72 @@ function BooleanCombinationSchema(int::Int, bool::Bool)
     return BooleanCombinationSchema(int, bool, JSG.AllOf{JSG.AnyOf{ConstantInt1Schema, ConstantInt2Schema}, JSG.Not{ConstantBoolTrueSchema}}())
 end
 
-schema = JSONSchema.Schema(JSG.schema(BooleanCombinationSchema))
+schema_dict = JSG.schema(BooleanCombinationSchema)
 
 good_json = JSON3.write(BooleanCombinationSchema(2, false))
 bad_json = JSON3.write(BooleanCombinationSchema(5, true))
 
-JSONSchema.validate(schema, good_json) === nothing
-JSONSchema.validate(schema, bad_json) !== nothing
+JSONSchema.validate(JSONSchema.Schema(schema_dict), good_json) === nothing
+JSONSchema.validate(JSONSchema.Schema(schema_dict), bad_json) !== nothing
+```
+
+The printed schema looks as follows:
+```julia
+julia> JSON.print(schema_dict, 2)
+{
+  "type": "object",
+  "properties": {
+    "int": {
+      "type": "integer"
+    },
+    "bool": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "int",
+    "bool"
+  ],
+  "allOf": [
+    {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "int": {
+              "const": 1
+            }
+          },
+          "required": [
+            "int"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "int": {
+              "const": 2
+            }
+          },
+          "required": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "not": {
+        "type": "object",
+        "properties": {
+          "bool": {
+            "const": true
+          }
+        },
+        "required": [
+          "bool"
+        ]
+      }
+    }
+  ]
+}
 ```

--- a/src/CombinationKeywordTypes.jl
+++ b/src/CombinationKeywordTypes.jl
@@ -1,0 +1,75 @@
+"""
+    AllOf{T}
+
+Type introduced for generating the JSON schema `allOf` keyword.
+
+Can be added to `combinationkeywords` for some Struct to add the keyword to the generated schema of that struct,
+    or chained with other keywords.
+
+# Example
+```julia
+combinationkeywords(MyStructType) = (AllOf{StructTypeA, StructTypeB}, Not{AllOf{StructTypeC, StructTypeD}})
+```
+"""
+struct AllOf{T,S} end
+
+"""
+    AnyOf{T}
+
+Type introduced for generating the JSON schema `anyOf` keyword.
+
+Can be added to `combinationkeywords` for some Struct to add the keyword to the generated schema of that struct,
+    or chained with other keywords.
+
+# Example
+```julia
+combinationkeywords(MyStructType) = (AnyOf{StructTypeA, StructTypeB}, Not{AnyOf{StructTypeC, StructTypeD}})
+```
+"""
+struct AnyOf{T,S} end
+
+"""
+    OneOf{T}
+
+Type introduced for generating the JSON schema `oneOf` keyword.
+
+Can be added to `combinationkeywords` for some Struct to add the keyword to the generated schema of that struct,
+    or chained with other keywords.
+
+# Example
+```julia
+combinationkeywords(MyStructType) = (OneOf{StructTypeA, StructTypeB}, Not{OneOf{StructTypeC, StructTypeD}})
+```
+"""
+struct OneOf{T,S} end
+
+"""
+    Not{T}
+
+Type introduced for generating the JSON schema `not` keyword.
+
+Can be added to `combinationkeywords` for some Struct to add the keyword to the generated schema of that struct,
+    or chained with other keywords.
+
+# Example
+```julia
+combinationkeywords(MyStructType) = (Not{StructA}, AnyOf{Not{StructB}, StructC})
+```
+"""
+struct Not{T} end
+
+"""
+    combinationkeywords(T::Type)::Tuple
+
+Specifies which JSON boolean combination keywords will be included in the generated schema for a type.
+
+Elements should be one of the following types: `AllOf{T,S}`, `AnyOf{T,S}`, `OneOf{T,S}`, `Not{T}`.
+
+# Example
+```julia
+combinationkeywords(MyStructType) = (AllOf{SchemaA, SchemaB}, Not{SchemaC})
+```
+"""
+function combinationkeywords end
+
+combinationkeywords(::Type) = ()

--- a/src/JSONSchemaGenerator.jl
+++ b/src/JSONSchemaGenerator.jl
@@ -8,14 +8,7 @@ if !isdefined(Base, :fieldtypes) && VERSION < v"1.1"
     fieldtypes(T::Type) = (Any[fieldtype(T, i) for i in 1:fieldcount(T)]...,)
 end
 
-# support boolean combinations of schemas by supplying the following types for use in structs
-struct AllOf{T,S} end
-struct AnyOf{T,S} end
-struct OneOf{T,S} end
-struct Not{T} end
-
-# add use of the above keywords to a struct by specifying a list of them to use with combinationkeywords
-combinationkeywords(::Type) = []
+include("CombinationKeywordTypes.jl")
 
 # by default we assume the type is a custom type, which should be a JSON object
 _json_type(::Type{<:Any}) = :object

--- a/src/JSONSchemaGenerator.jl
+++ b/src/JSONSchemaGenerator.jl
@@ -121,19 +121,19 @@ function _generate_json_object(julia_type::Type, settings::SchemaSettings)
         name_string = string(name)
         # check for keywords
         if type <: AllOf
-            @assert (name_string == "allOf") "element of type AllOf in $(nameof(julia_type)) should have the name allOf, currently has name $(name)" # avoid mulitple uses in one object
+            @assert (name_string == "allOf") "element of type AllOf in $(nameof(julia_type)) should have the name allOf, currently has name $(name_string)" # avoid mulitple uses in one object
             allOfDict = _generate_json_type_def(type, settings)
             continue # don't add allOf keyword to properties
         elseif type <: AnyOf
-            @assert (name_string == "anyOf") "element of type AnyOf in $(nameof(julia_type)) should have the name anyOf, currently has name $(name)" # avoid mulitple uses in one object
+            @assert (name_string == "anyOf") "element of type AnyOf in $(nameof(julia_type)) should have the name anyOf, currently has name $(name_string)" # avoid mulitple uses in one object
             anyOfDict = _generate_json_type_def(type, settings)
             continue # don't add anyOf keyword to properties
         elseif type <: OneOf
-            @assert (name_string == "oneOf") "element of type AnyOf in $(nameof(julia_type)) should have the name oneOf, currently has name $(name)" # avoid mulitple uses in one object
+            @assert (name_string == "oneOf") "element of type AnyOf in $(nameof(julia_type)) should have the name oneOf, currently has name $(name_string)" # avoid mulitple uses in one object
             oneOfDict = _generate_json_type_def(type, settings)
             continue # don't add oneOf keyword to properties
         elseif type <: Not
-            @assert (name_string == "not") "element of type AnyOf in $(nameof(julia_type)) should have the name not, currently has name $(name)" # avoid mulitple uses in one object
+            @assert (name_string == "not") "element of type AnyOf in $(nameof(julia_type)) should have the name not, currently has name $(name_string)" # avoid mulitple uses in one object
             notDict = _generate_json_type_def(type, settings)
             continue # don't add not keyword to properties
         end

--- a/src/JSONSchemaGenerator.jl
+++ b/src/JSONSchemaGenerator.jl
@@ -29,6 +29,7 @@ _json_type(::Type{T}) where {T <: Dates.TimeType} = :string
 _json_type(::Type{VersionNumber}) = :string
 _json_type(::Type{Base.Regex}) = :string
 _json_type(::Type{<:Val}) = :const
+_json_type(::Type{<:Tuple}) = :enum
 _json_type(::Type{<:AllOf}) = :keyword
 _json_type(::Type{<:AnyOf}) = :keyword
 _json_type(::Type{<:OneOf}) = :keyword
@@ -170,6 +171,12 @@ end
 function _generate_json_type_def(::Val{:const}, julia_type::Type{<:Val}, settings::SchemaSettings)
     return settings.dict_type{String, Any}(
         "const" => julia_type.parameters[1]
+    )
+end
+
+function _generate_json_type_def(::Val{:enum}, julia_type::Type{<:Tuple}, settings::SchemaSettings)
+    return settings.dict_type{String, Any}(
+        "enum" => [p isa Symbol ? String(p) : p for p in julia_type.parameters]
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,6 +106,8 @@ module TestTypes
     function BooleanCombinationSchema(int::Int, bool::Bool)
         return BooleanCombinationSchema(int, bool, JSG.AllOf{JSG.AnyOf{ConstantInt1Schema, ConstantInt2Schema}, JSG.Not{ConstantBoolTrueSchema}}())
     end
+    StructTypes.StructType(::Type{BooleanCombinationSchema}) = StructTypes.Struct()
+    StructTypes.excludes(::Type{BooleanCombinationSchema}) = (:allOf,)
 end
 
 function test_json_schema_validation(obj::T) where T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,8 @@ using StructTypes
 module TestTypes
     using Dates
     using StructTypes
-    import JSONSchemaGenerator as JSG
+    import JSONSchemaGenerator
+    const JSG = JSONSchemaGenerator
 
     struct BasicSchema
         int::Int64

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,8 +90,8 @@ module TestTypes
     struct ConstantInt1Schema
         int::Val{1}
     end
-    struct ConstantInt2Schema
-        int::Val{2}
+    struct EnumInt2Or3Schema
+        int::Tuple{2,3}
     end
     struct ConstantBoolTrueSchema
         bool::Val{true}
@@ -102,7 +102,7 @@ module TestTypes
     end
     JSG.combinationkeywords(::Type{BooleanCombinationSchema}) = [
         JSG.AllOf{
-            JSG.AnyOf{ConstantInt1Schema, ConstantInt2Schema},
+            JSG.AnyOf{ConstantInt1Schema, EnumInt2Or3Schema},
             JSG.Not{ConstantBoolTrueSchema}
         }
     ]
@@ -114,7 +114,7 @@ module TestTypes
     StructTypes.StructType(::Type{BadBooleanCombinationSchema}) = StructTypes.Struct()
     JSG.combinationkeywords(::Type{BadBooleanCombinationSchema}) = [
         JSG.AllOf{ConstantInt1Schema, ConstantInt1Schema},
-        JSG.AllOf{ConstantInt2Schema, ConstantInt2Schema}
+        JSG.AllOf{EnumInt2Or3Schema, EnumInt2Or3Schema}
     ]
 
     struct BadBooleanCombinationSchema2
@@ -312,14 +312,16 @@ end
     @testset "Good weather" begin
         combo_schema = JSONSchemaGenerator.schema(TestTypes.BooleanCombinationSchema)
         constantint1_schema = JSONSchemaGenerator.schema(TestTypes.ConstantInt1Schema)
-        constantint2_schema = JSONSchemaGenerator.schema(TestTypes.ConstantInt2Schema)
+        enumint2or3_schema = JSONSchemaGenerator.schema(TestTypes.EnumInt2Or3Schema)
         constantbooltrue_schema = JSONSchemaGenerator.schema(TestTypes.ConstantBoolTrueSchema)
 
         @test combo_schema["allOf"][1]["anyOf"][1] == constantint1_schema
-        @test combo_schema["allOf"][1]["anyOf"][2] == constantint2_schema
+        @test combo_schema["allOf"][1]["anyOf"][2] == enumint2or3_schema
         @test combo_schema["allOf"][2]["not"] == constantbooltrue_schema
 
         test_json_schema_validation(TestTypes.BooleanCombinationSchema(1, false))
+        test_json_schema_validation(TestTypes.BooleanCombinationSchema(2, false))
+        test_json_schema_validation(TestTypes.BooleanCombinationSchema(3, false))
     end
 
     @testset "Multiple uses of same keyword in one object" begin


### PR DESCRIPTION
Was wanting to use the JSON boolean combination keywords (https://json-schema.org/understanding-json-schema/reference/combining#boolean-json-schema-combination) in a schema but still have the schema automatically generated.

Main changes:
- Added new types AllOf{T,S}, AnyOf{T,S}, OneOf{T,S}, Not{T} whose use in a struct allows the schema generator to add the corresponding keywords
- Made it so that the schema generator will interpret Val types in structs as JSON const values (e.g. x::Val{true} -> x : { const : true })

Included an extra test making use of these changes.

Let me know if you think there's a nicer way to do this!